### PR TITLE
Add support for validating other workload kinds as well as pods

### DIFF
--- a/cmd/kubernetes-admission-controller/types.go
+++ b/cmd/kubernetes-admission-controller/types.go
@@ -49,12 +49,12 @@ type SelectorResourceType string
 type GateModeType string
 
 const (
-	PodSelectorType       SelectorResourceType = "pod"
+	ResourceSelectorType  SelectorResourceType = "resource"
 	NamespaceSelectorType SelectorResourceType = "namespace"
 	ImageSelectorType     SelectorResourceType = "image"
-	PolicyGateMode        GateModeType = "policy"
-	AnalysisGateMode      GateModeType = "analysis"
-	BreakGlassMode        GateModeType = "breakglass"
+	PolicyGateMode        GateModeType         = "policy"
+	AnalysisGateMode      GateModeType         = "analysis"
+	BreakGlassMode        GateModeType         = "breakglass"
 )
 
 

--- a/skaffold-values-file.yaml
+++ b/skaffold-values-file.yaml
@@ -17,7 +17,7 @@ policySelectors:
       PolicyBundleId: bundle1
     Mode: policy
   - Selector:
-      ResourceType: pod
+      ResourceType: resource
       SelectorKeyRegex: stage
       SelectorValueRegex: testing
     PolicyReference:


### PR DESCRIPTION
Adds support for directly validating the other workload kinds that contain pod specs. For non-Pod types, the pod spec is extracted from the resource spec and all container images are validated using the same selectors and configuration options as a pod.

Resolves #18 