### PR TITLE
Refactor main tests

### DIFF
--- a/cmd/kubernetes-admission-controller/main_test.go
+++ b/cmd/kubernetes-admission-controller/main_test.go
@@ -410,32 +410,7 @@ func TestMatchImageRef(t *testing.T) {
 }
 
 func TestValidatePolicyOk(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -491,31 +466,7 @@ func TestValidatePolicyOk(t *testing.T) {
 }
 
 func TestValidatePolicyFail(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodFailResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -525,7 +476,7 @@ func TestValidatePolicyFail(t *testing.T) {
 		Spec: v1.PodSpec{Containers: []v1.Container{
 			{
 				Name:    "Container1",
-				Image:   "alpine",
+				Image:   "bad-alpine",
 				Command: []string{"bin/bash", "bin"},
 			},
 		},
@@ -568,35 +519,11 @@ func TestValidatePolicyFail(t *testing.T) {
 		fmt.Println(string(obj[:]))
 	}
 
-	assert.True(t, !resp.Allowed)
+	assert.False(t, resp.Allowed)
 }
 
 func TestValidatePolicyNotFound(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -652,32 +579,7 @@ func TestValidatePolicyNotFound(t *testing.T) {
 }
 
 func TestValidateAnalyzedOk(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -733,31 +635,7 @@ func TestValidateAnalyzedOk(t *testing.T) {
 }
 
 func TestValidateAnalyzedFail(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -813,31 +691,7 @@ func TestValidateAnalyzedFail(t *testing.T) {
 }
 
 func TestValidatePassiveFound(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -893,31 +747,7 @@ func TestValidatePassiveFound(t *testing.T) {
 }
 
 func TestValidatePassiveNotFound(t *testing.T) {
-	//Setup test service
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/images" {
-			switch r.URL.Path {
-			case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
-				fmt.Fprintln(w, GoodPassResponse)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageNotFound)
-			}
-		} else {
-			switch r.URL.Query().Get("fulltag") {
-			case "docker.io/alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "alpine":
-				fmt.Fprintln(w, ImageLookup)
-			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, ImageLookupError)
-			}
-		}
-	}))
-
+	ts := createTestService()
 	defer ts.Close()
 
 	adm := admissionHook{}
@@ -972,7 +802,42 @@ func TestValidatePassiveNotFound(t *testing.T) {
 	assert.True(t, resp.Allowed)
 }
 
-var GoodPassResponse = `
+func createTestService() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/images" {
+			switch r.URL.Query().Get("fulltag") {
+			case "docker.io/alpine:latest", "docker.io/alpine", "alpine":
+				fmt.Fprintln(w, AlpineImageLookup)
+				return
+			case "docker.io/bad-alpine:latest", "docker.io/bad-alpine", "bad-alpine":
+				fmt.Fprintln(w, BadAlpineImageLookup)
+				return
+			}
+
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, ImageLookupError)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/images/sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
+			fmt.Fprintln(w, GoodPassResponse)
+			return
+		case "/images/sha256:11111826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b/check":
+			fmt.Fprintln(w, GoodFailResponse)
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, ImageNotFound)
+	}))
+
+	return ts
+}
+
+const GoodPassResponse = `
 [
   {
     "sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b": {
@@ -988,7 +853,8 @@ var GoodPassResponse = `
   }
 ]
 `
-var GoodFailResponse = `
+
+const GoodFailResponse = `
 [
   {
     "sha256:02892826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b": {
@@ -1005,21 +871,13 @@ var GoodFailResponse = `
 ]
 `
 
-var ImageNotFound = `
+const ImageNotFound = `
 {  
   "message": "could not get image record from anchore"
 }
 `
 
-var PolicyNotFound = `
-{
-    "detail": {},
-    "httpcode": 404,
-    "message": "Policy bundle notreal not found in DB"
-}
-`
-
-var ImageLookup = `
+const AlpineImageLookup = `
 [
   {
     "analysis_status": "analyzed",
@@ -1063,7 +921,51 @@ var ImageLookup = `
 ]
 `
 
-var ImageLookupError = `{"detail": {}, "httpcode": 404, "message": "image data not found in DB" }`
+const BadAlpineImageLookup = `
+[
+  {
+    "analysis_status": "analyzed",
+    "analyzed_at": "2018-12-03T18:24:54Z",
+    "annotations": {},
+    "created_at": "2018-12-03T18:24:43Z",
+    "imageDigest": "sha256:11111826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b",
+    "image_content": {
+      "metadata": {
+        "arch": "amd64",
+        "distro": "alpine",
+        "distro_version": "3.8.1",
+        "dockerfile_mode": "Guessed",
+        "image_size": 2206931,
+        "layer_count": 1
+      }
+    },
+    "image_detail": [
+      {
+        "created_at": "2018-12-03T18:24:43Z",
+        "digest": "sha256:11111826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b",
+        "dockerfile": "RlJPTSBzY3JhdGNoCkFERCBmaWxlOjI1YzEwYjFkMWI0MWQ0NmExODI3YWQwYjBkMjM4OWMyNGRmNmQzMTQzMDAwNWZmNGU5YTJkODRlYTIzZWJkNDIgaW4gLyAKQ01EIFsiL2Jpbi9zaCJdCg==",
+        "fulldigest": "docker.io/bad-alpine@sha256:11111826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b",
+        "fulltag": "docker.io/bad-alpine:latest",
+        "imageDigest": "sha256:11111826401a9d18f0ea01f8a2f35d328ef039db4e1edcc45c630314a0457d5b",
+        "imageId": "196d12cf6ab19273823e700516e98eb1910b03b17840f9d5509f03858484d321",
+        "last_updated": "2018-12-03T18:24:54Z",
+        "registry": "docker.io",
+        "repo": "bad-alpine",
+        "tag": "latest",
+        "tag_detected_at": "2018-12-03T18:24:43Z",
+        "userId": "admin"
+      }
+    ],
+    "image_status": "active",
+    "image_type": "docker",
+    "last_updated": "2018-12-03T18:24:54Z",
+    "parentDigest": "sha256:621c2f39f8133acb8e64023a94dbdf0d5ca81896102b9e57c0dc184cadaf5528",
+    "userId": "admin"
+  }
+]
+`
+
+const ImageLookupError = `{"detail": {}, "httpcode": 404, "message": "image data not found in DB" }`
 
 func TestLookupImage(t *testing.T) {
 	t.Log("Testing image lookup handling")
@@ -1075,7 +977,7 @@ func TestLookupImage(t *testing.T) {
 		} else {
 			switch r.URL.Query().Get("fulltag") {
 			case "docker.io/alpine:latest":
-				fmt.Fprintln(w, ImageLookup)
+				fmt.Fprintln(w, AlpineImageLookup)
 			default:
 				w.WriteHeader(http.StatusNotFound)
 				fmt.Fprint(w, ImageLookupError)

--- a/cmd/kubernetes-admission-controller/main_test.go
+++ b/cmd/kubernetes-admission-controller/main_test.go
@@ -201,18 +201,7 @@ func TestConfig(t *testing.T) {
 
 }
 
-func TestMatchObjectMetadata(t *testing.T) {
-	//_, logErr := initLogger()
-	//if logErr != nil {
-	//	fmt.Println("Failed to initialize logging: ", logErr)
-	//
-	//}
-
-	var meta metav1.ObjectMeta
-	var selector ResourceSelector
-	var err error
-	var found bool
-
+func testMetadata() metav1.ObjectMeta {
 	labels := map[string]string{
 		"labelkey":   "lvalue",
 		"labelkey2":  "lvalue2",
@@ -225,187 +214,150 @@ func TestMatchObjectMetadata(t *testing.T) {
 		"annotationowner": "asometeam",
 	}
 
-	meta = metav1.ObjectMeta{Labels: labels, Annotations: annotations}
-
-	// Match anything
-	selector = ResourceSelector{PodSelectorType, ".*", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	// Match Labels
-	selector = ResourceSelector{PodSelectorType, "label.*", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "^label$", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if found || err != nil {
-		t.Fatal("Incorrectly matched")
-
-	} else {
-		t.Log("Did not match, correctly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "label", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "labelowner", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "labelowner", "lsometeam"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "labelowner", "lsome"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, ".*", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	// Match annotations
-	selector = ResourceSelector{PodSelectorType, "annotation.*", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "annotationowner", "asometeam"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched all properly")
-	}
-
-	// Correctly fail to match
-	selector = ResourceSelector{PodSelectorType, "own", ".*team"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched prefix properly")
-	}
-
-	selector = ResourceSelector{PodSelectorType, "notfound", ".*"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Log("Correctly failed to match")
-	} else {
-		t.Log("Incorrectly matched")
-
-	}
-
-	selector = ResourceSelector{PodSelectorType, ".*", "anotherteam"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Log("Correctly failed to match")
-	} else {
-		t.Log("Incorrectly matched")
-
-	}
-
-	selector = ResourceSelector{PodSelectorType, "owner", "anotherteam"}
-	found, err = matchObjMetadata(&selector, &meta)
-	if !found || err != nil {
-		t.Log("Correctly failed to match")
-	} else {
-		t.Log("Incorrectly matched")
-
-	}
-
-	// Match image
-	selector = ResourceSelector{ImageSelectorType, ".*", ".*"}
-	found, err = matchImageResource(selector.SelectorValueRegex, "alpine")
-	if found && err == nil {
-		t.Log("Correctly matched")
-	} else {
-		t.Log("Incorrectly failed to match")
-
-	}
-
-	selector = ResourceSelector{ImageSelectorType, ".*", ".*:latest"}
-	found, err = matchImageResource(selector.SelectorValueRegex, "alpine:latest")
-	if found && err == nil {
-		t.Log("Correctly matched")
-	} else {
-		t.Log("Incorrectly failed to match")
-
-	}
-
-	selector = ResourceSelector{ImageSelectorType, ".*", ".*:latest"}
-	found, err = matchImageResource(selector.SelectorValueRegex, "debian:jessie")
-	if !found && err == nil {
-		t.Log("Correctly failed to match")
-	} else {
-		t.Log("Incorrectly matched or error")
-
-	}
-
+	return metav1.ObjectMeta{Labels: labels, Annotations: annotations}
 }
 
-func TestMatchImageRef(t *testing.T) {
-	var selector ResourceSelector
+func assertShouldMatch(t *testing.T, found bool, err error) {
+	t.Helper()
 
-	selector = ResourceSelector{ImageSelectorType, ".*", ".*"}
-	found, err := matchImageResource(selector.SelectorValueRegex, "alpine")
 	if !found || err != nil {
 		t.Fatal("Failed to match")
-
-	} else {
-		t.Log("Matched prefix properly")
 	}
 
-	selector = ResourceSelector{ImageSelectorType, "", "alpine"}
-	found, err = matchImageResource(selector.SelectorValueRegex, "alpine")
-	if !found || err != nil {
-		t.Fatal("Failed to match")
+	t.Log("Matched all properly")
+}
 
-	} else {
-		t.Log("Matched prefix properly")
+func assertShouldNotMatch(t *testing.T, found bool, err error) {
+	t.Helper()
+
+	if found || err != nil {
+		t.Fatal("Incorrectly matched")
+	}
+
+	t.Log("Correctly did not match")
+}
+
+func TestMatchObjMetadata(t *testing.T) {
+	testCases := []struct {
+		name      string
+		selector  ResourceSelector
+		assertion func(t *testing.T, found bool, err error)
+	}{
+		{
+			name:      "should match anything",
+			selector:  ResourceSelector{PodSelectorType, ".*", ".*"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'label.*'",
+			selector:  ResourceSelector{PodSelectorType, "label.*", ".*"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should NOT match key '^label$'",
+			selector:  ResourceSelector{PodSelectorType, "^label$", ".*"},
+			assertion: assertShouldNotMatch,
+		},
+		{
+			name:      "should match key 'label'",
+			selector:  ResourceSelector{PodSelectorType, "label", ".*"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'labelowner'",
+			selector:  ResourceSelector{PodSelectorType, "labelowner", ".*"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'labelowner' with value 'lsometeam'",
+			selector:  ResourceSelector{PodSelectorType, "labelowner", "lsometeam"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'labelowner' with value 'lsome'",
+			selector:  ResourceSelector{PodSelectorType, "labelowner", "lsome"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'annotation.*'",
+			selector:  ResourceSelector{PodSelectorType, "annotation.*", ".*"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'annotationowner' with value 'asometeam'",
+			selector:  ResourceSelector{PodSelectorType, "annotationowner", "asometeam"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should match key 'own' with value '.*team'",
+			selector:  ResourceSelector{PodSelectorType, "own", ".*team"},
+			assertion: assertShouldMatch,
+		},
+		{
+			name:      "should NOT match key 'notfound'",
+			selector:  ResourceSelector{PodSelectorType, "notfound", ".*"},
+			assertion: assertShouldNotMatch,
+		},
+		{
+			name:      "should NOT match value 'anotherteam'",
+			selector:  ResourceSelector{PodSelectorType, ".*", "anotherteam"},
+			assertion: assertShouldNotMatch,
+		},
+		{
+			name:      "should NOT match key 'owner' with value 'anotherteam'",
+			selector:  ResourceSelector{PodSelectorType, "owner", "anotherteam"},
+			assertion: assertShouldNotMatch,
+		},
+	}
+
+	metadata := testMetadata()
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			found, err := matchObjMetadata(&testCase.selector, &metadata)
+			testCase.assertion(t, found, err)
+		})
+	}
+}
+
+func TestMatchImageResource(t *testing.T) {
+	testCases := []struct {
+		name               string
+		selectorValueRegex string
+		image              string
+		assertion          func(t *testing.T, found bool, err error)
+	}{
+		{
+			name:               "match any image",
+			selectorValueRegex: ".*",
+			image:              "alpine",
+			assertion:          assertShouldMatch,
+		},
+		{
+			name:               "match image with same tag",
+			selectorValueRegex: ".*:latest",
+			image:              "alpine:latest",
+			assertion:          assertShouldMatch,
+		},
+		{
+			name:               "don't match image with different tag",
+			selectorValueRegex: ".*:latest",
+			image:              "debian:jessie",
+			assertion:          assertShouldNotMatch,
+		},
+		{
+			name:               "match image by exact name",
+			selectorValueRegex: "alpine",
+			image:              "alpine",
+			assertion:          assertShouldMatch,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			found, err := matchImageResource(testCase.selectorValueRegex, testCase.image)
+			testCase.assertion(t, found, err)
+		})
 	}
 }
 


### PR DESCRIPTION
Refactors test code in `cmd/kubernetes-admission-controller/main_test.go` with two objectives:

1. Learning my way around this code, using tests as the describers of expected functionality
2. Making it easier to add new test scenarios, particularly for validation of new object kinds (beyond _pods_)