### PR TITLE
Ensure no build cache on docker build via the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build-debug: ## Build all binaries with remote debugging capabilities
 .PHONY: docker
 docker: ## Build a Docker image
 	@${MAKE} GOOS=linux GOARCH=amd64 build-release
-	docker build -t ${DOCKER_IMAGE} -f Dockerfile .
+	docker build --no-cache -t ${DOCKER_IMAGE} -f Dockerfile .
 
 .PHONY: goversion
 goversion:


### PR DESCRIPTION
Ensures the build cache isn't used for the docker build since the instruction matches can cause stale code to be used in the 2nd phase due to the way docker does cache matches.