### PR TITLE
chore: fix release.yaml workflow name and use of creds to do release image push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: default
+name: release
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,12 @@ jobs:
     - name: Setup Ko
       uses: imjasonh/setup-ko@v0.6
 
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.TOOLBOX_DOCKER_USER }}
+        password: ${{ secrets.TOOLBOX_DOCKER_PASS }}
+
     - name: Release Container
       run: make release


### PR DESCRIPTION
Just a workflow name update to make things more clear.