### PR TITLE
feat: upgrade golang to 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Test
       run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Go tests
       run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine AS builder
+FROM golang:1.19-alpine AS builder
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DOCKER_TAG ?= $(VERSION)
 
 ANCHORE_VERSION = 156836d
 OPENAPI_GENERATOR_VERSION = v4.1.3
-GOLANG_VERSION = 1.18
+GOLANG_VERSION = 1.19
 
 ifeq "$(strip $(VERSION))" ""
  override VERSION = $(shell git describe --always --tags --dirty)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/kubernetes-admission-controller
 
-go 1.18
+go 1.19
 
 require (
 	github.com/antihax/optional v1.0.0


### PR DESCRIPTION
Go 1.18 will become EOL with the upcoming release of Go 1.20
