### PR TITLE
feat: bump go to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/anchore/kubernetes-admission-controller
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.22.5
 
 require (
 	github.com/anchore/enterprise-client-go v1.0.1-0.20230918181600-6fa3897cc2a7


### PR DESCRIPTION
addresses CVE-2024-24790

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
