### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,9 @@ help track their provenance.
 
 ## Deploy
 
-The tested way to deploy the controller is with the [Helm Chart](https://github.com/anchore/anchore-charts/tree/master/stable/anchore-admission-controller), see the chart README for more details
+The tested way to deploy the controller is with the [Helm Chart](https://github.com/anchore/anchore-charts/tree/main/stable/anchore-admission-controller), see the chart README for more details
 on its own configuration including tls/cert setup that is necessary to have the k8s apiserver contact the controller securely.
 
-## Build
-
-`make docker` Should be all that is necessary to build.
  
 ## Environment Variables
 


### PR DESCRIPTION
Updated Helm chart link to point from 'master' to 'main'. Removed build instruction 'make docker' as it currently throws an error instead of running as expected;

```
$ make docker
make: *** No rule to make target 'docker'.  Stop.
```